### PR TITLE
Allow query_id paramter when rendering sidebar

### DIFF
--- a/lib/query_share/patches/queries_helper_patch.rb
+++ b/lib/query_share/patches/queries_helper_patch.rb
@@ -22,7 +22,7 @@ module QueriesHelper
                       css = 'query'
                       css << ' selected' if query == @query
                       css << " visible#{query.visibility}"
-                      content_tag('li', link_to(query.name, url_params.permit(:query_id).merge(:query_id => query), :class => css,
+                      content_tag('li', link_to(query.name, request.params.merge({:query_id => query}), :class => css,
                                                 :title => l(:field_author) + ": #{query.user.name}"))
                     }.join("\n").html_safe,
                     :class => 'queries'

--- a/lib/query_share/patches/queries_helper_patch.rb
+++ b/lib/query_share/patches/queries_helper_patch.rb
@@ -22,7 +22,7 @@ module QueriesHelper
                       css = 'query'
                       css << ' selected' if query == @query
                       css << " visible#{query.visibility}"
-                      content_tag('li', link_to(query.name, url_params.merge(:query_id => query), :class => css,
+                      content_tag('li', link_to(query.name, url_params.permit(:query_id).merge(:query_id => query), :class => css,
                                                 :title => l(:field_author) + ": #{query.user.name}"))
                     }.join("\n").html_safe,
                     :class => 'queries'


### PR DESCRIPTION
When rendering the sidebar links (at least in the gantt view) we need to allow the query_id parameter in the link.